### PR TITLE
Redesigned prototype to implement the OrientDB Hibernate OGM Provider.

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -27,7 +27,7 @@
         <infinispanVersion>8.0.2.Final</infinispanVersion>
         <mongodbVersion>3.0.3</mongodbVersion>
         <fongodbVersion>2.0.2</fongodbVersion>
-        <orientdbVersion>2.1.9</orientdbVersion>
+        <orientdbVersion>2.1.12</orientdbVersion>
         <neo4jVersion>2.3.2</neo4jVersion>
         <!-- Update dependency versions accordingly when updating C*  -->
         <cassandraVersion>2.2.0-rc3</cassandraVersion>

--- a/orientdb/src/main/java/org/hibernate/datastore/ogm/orientdb/OrientDBDialect.java
+++ b/orientdb/src/main/java/org/hibernate/datastore/ogm/orientdb/OrientDBDialect.java
@@ -6,260 +6,165 @@
  */
 package org.hibernate.datastore.ogm.orientdb;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-
-import org.hibernate.datastore.ogm.orientdb.dialect.impl.OrientDBAssociationQueries;
-import org.hibernate.datastore.ogm.orientdb.dialect.impl.OrientDBEntityQueries;
+import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
+import com.orientechnologies.orient.core.id.ORecordId;
+import com.orientechnologies.orient.core.record.impl.ODocument;
+import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
+import org.hibernate.datastore.ogm.orientdb.dialect.impl.OrientDBQueryHelper;
 import org.hibernate.datastore.ogm.orientdb.dialect.impl.OrientDBTupleSnapshot;
 import org.hibernate.datastore.ogm.orientdb.impl.OrientDBDatastoreProvider;
 import org.hibernate.datastore.ogm.orientdb.logging.impl.Log;
 import org.hibernate.datastore.ogm.orientdb.logging.impl.LoggerFactory;
 import org.hibernate.datastore.ogm.orientdb.type.spi.ORecordIdGridType;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.ogm.dialect.identity.spi.IdentityColumnAwareGridDialect;
-import org.hibernate.ogm.dialect.spi.AssociationContext;
-import org.hibernate.ogm.dialect.spi.AssociationTypeContext;
-import org.hibernate.ogm.dialect.spi.BaseGridDialect;
-import org.hibernate.ogm.dialect.spi.ModelConsumer;
-import org.hibernate.ogm.dialect.spi.NextValueRequest;
-import org.hibernate.ogm.dialect.spi.SessionFactoryLifecycleAwareDialect;
-import org.hibernate.ogm.dialect.spi.TupleAlreadyExistsException;
-import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.dialect.batch.spi.OperationsQueue;
+import org.hibernate.ogm.dialect.spi.*;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.model.spi.Association;
 import org.hibernate.ogm.model.spi.Tuple;
-import org.hibernate.ogm.persister.impl.OgmCollectionPersister;
-import org.hibernate.ogm.persister.impl.OgmEntityPersister;
+import org.hibernate.ogm.model.spi.TupleOperation;
 import org.hibernate.ogm.type.spi.GridType;
-import org.hibernate.persister.collection.CollectionPersister;
-import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.type.Type;
 
-import com.orientechnologies.orient.core.id.ORecordId;
+import java.util.Set;
 
 /**
  * @author Sergey Chernolyas (sergey.chernolyas@gmail.com)
+ * @author cristhiank (calovi86 at gmail.com)
  */
-public class OrientDBDialect extends BaseGridDialect
-		implements SessionFactoryLifecycleAwareDialect, IdentityColumnAwareGridDialect {
+public class OrientDBDialect extends BaseGridDialect {
 
-	private static final Log log = LoggerFactory.getLogger();
+    private static final Log log = LoggerFactory.getLogger();
+    private OrientDBDatastoreProvider provider;
 
-	private OrientDBDatastoreProvider provider;
-	private Map<AssociationKeyMetadata, OrientDBAssociationQueries> associationQueries;
-	private Map<EntityKeyMetadata, OrientDBEntityQueries> entityQueries;
+    public OrientDBDialect(OrientDBDatastoreProvider provider) {
+        this.provider = provider;
+    }
 
-	public OrientDBDialect(OrientDBDatastoreProvider provider) {
-		this.provider = provider;
-	}
 
-	@Override
-	public Tuple getTuple(EntityKey key, TupleContext tupleContext) {
-		log.info( "getTuple:EntityKey:" + key + "; tupleContext" + tupleContext );
-		ORecordId dbKey = null;
-		for ( int i = 0; i < key.getColumnNames().length; i++ ) {
-			String columnName = key.getColumnNames()[i];
-			Object columnValue = key.getColumnValues()[i];
-			log.info( "EntityKey: columnName: " + columnName + ";columnValue: " + columnValue + " (class:" + columnValue.getClass().getName() + ");" );
-			if ( columnName.equals( "@rid" ) ) {
-				dbKey = (ORecordId) columnValue;
-			}
-		}
+    public ODocument findRecordByKey(ODatabaseDocumentTx executionEngine, EntityKey key, TupleContext tupleContext) {
+        //TODO: include tupleContext selectableColumns projection ??
+        OSQLSynchQuery<ODocument> orientQuery = OrientDBQueryHelper.createSelect(key);
+        return executionEngine.command(orientQuery).execute();
+    }
 
-		if ( dbKey.getClusterPosition() == ORecordId.EMPTY_RECORD_ID.getClusterPosition() ) {
-			// is is temporary value. no entity in db with this key
-			log.info( "getTuple:Key:" + dbKey + "is temporary!" );
-			return null;
-		}
+    private ODocument prepareObjectWithPk(EntityKey key) {
+        ODocument object = new ODocument();
+        String[] columnNames = key.getColumnNames();
+        Object[] columnValues = key.getColumnValues();
+        for (int i = 0; i < columnNames.length; i++) {
+            object.field(columnNames[i], columnValues[i]);
+        }
+        return object;
+    }
 
-		try {
-			Map<String, Object> dbValuesMap = entityQueries.get( key.getMetadata() ).findEntity( provider.getConnection(), key.getColumnValues() );
-			return new Tuple(
-					new OrientDBTupleSnapshot( dbValuesMap, tupleContext.getAllAssociatedEntityKeyMetadata(), tupleContext.getAllRoles(), key.getMetadata() ) );
-		}
-		catch (SQLException e) {
-			log.error( "Can not find entity", e );
-		}
-		return null;
-	}
+    @Override
+    public Tuple getTuple(EntityKey key, TupleContext tupleContext) {
+        ODocument document = findRecordByKey(provider.getConnection(), key, tupleContext);
+        OrientDBTupleSnapshot tuple;
+        if (document == null) {
+            tuple = new OrientDBTupleSnapshot(prepareObjectWithPk(key), key.getMetadata(), OrientDBTupleSnapshot.SnapshotType.INSERT);
+        } else if (isInTheQueue(key, tupleContext)) {
+            tuple = new OrientDBTupleSnapshot(document, key.getMetadata(), OrientDBTupleSnapshot.SnapshotType.UPDATE);
+        } else {
+            return null;
+        }
+        return new Tuple(tuple);
+    }
 
-	@Override
-	public Tuple createTuple(EntityKey key, TupleContext tupleContext) {
-		log.info( "createTuple:EntityKey:" + key + "; tupleContext" + tupleContext );
-		return new Tuple( new OrientDBTupleSnapshot( key.getMetadata() ) );
-	}
+    private boolean isInTheQueue(EntityKey key, TupleContext tupleContext) {
+        OperationsQueue queue = tupleContext.getOperationsQueue();
+        return queue != null && queue.contains(key);
+    }
 
-	@Override
-	public Tuple createTuple(EntityKeyMetadata entityKeyMetadata, TupleContext tupleContext) {
-		throw new UnsupportedOperationException( "Not supported yet." );
-	}
+    @Override
+    public Tuple createTuple(EntityKey key, TupleContext tupleContext) {
+        log.info("createTuple:EntityKey:" + key + "; tupleContext" + tupleContext);
+        ODocument newObject = prepareObjectWithPk(key);
+        return new Tuple(new OrientDBTupleSnapshot(newObject, key.getMetadata(), OrientDBTupleSnapshot.SnapshotType.INSERT));
+    }
 
-	@Override
-	public void insertOrUpdateTuple(EntityKey key, Tuple tuple, TupleContext tupleContext) throws TupleAlreadyExistsException {
-		log.info( "insertOrUpdateTuple:EntityKey:" + key + "; tupleContext" + tupleContext + "; tuple:" + tuple );
-		Connection connection = provider.getConnection();
 
-		StringBuilder queryBuffer = new StringBuilder();
-		ORecordId dbKey = null;
-		for ( int i = 0; i < key.getColumnNames().length; i++ ) {
-			String columnName = key.getColumnNames()[i];
-			Object columnValue = key.getColumnValues()[i];
-			log.info( "EntityKey: columnName: " + columnName + ";columnValue: " + columnValue + " (class:" + columnValue.getClass().getName() + ");" );
-			if ( columnName.equals( "@rid" ) ) {
-				dbKey = (ORecordId) columnValue;
-			}
-		}
-		if ( dbKey.getClusterPosition() == ORecordId.EMPTY_RECORD_ID.getClusterPosition() ) {
-			// it is new record =>insert a new record!
-			log.info( "insertOrUpdateTuple:Key:" + dbKey + "is temporary!. Insert new record" );
+    @Override
+    public void insertOrUpdateTuple(EntityKey key, Tuple tuple, TupleContext tupleContext) throws TupleAlreadyExistsException {
+        log.info("insertOrUpdateTuple:EntityKey:" + key + "; tupleContext" + tupleContext + "; tuple:" + tuple);
+        ODatabaseDocumentTx connection = provider.getConnection();
+        ODocument recordByKey = findRecordByKey(connection, key, tupleContext);
+        if (recordByKey == null) {
+            //Doesn't exist, create it.
+            createOrientDBRecord(key, tuple, tupleContext, connection);
+        }
+    }
 
-			queryBuffer.append( "insert into " ).append( key.getTable() );
-			if ( tuple.getColumnNames().size() > 1 ) {
-				queryBuffer.append( " set " );
-			}
-			for ( String columnName : tuple.getColumnNames() ) {
-				if ( columnName.equals( "@rid" ) ) {
-					continue;
-				}
-				// @TODO correct type
-				queryBuffer.append( " " ).append( columnName ).append( "='" ).append( tuple.get( columnName ) ).append( "'," );
-			}
-			queryBuffer.setLength( queryBuffer.length() - 1 );
-			log.info( "insertOrUpdateTuple:Key:" + dbKey + ". insert query:" + queryBuffer.toString() );
-			try {
-				PreparedStatement pstmt = connection.prepareStatement( queryBuffer.toString() );
-				log.info( "insertOrUpdateTuple:Key:" + dbKey + ". inserted: " + pstmt.executeUpdate() );
-			}
-			catch (SQLException e) {
-				log.error( "Can not find entity", e );
-				throw new RuntimeException( e );
-			}
+    private void createOrientDBRecord(EntityKey key, Tuple tuple, TupleContext tupleContext, ODatabaseDocumentTx connection) {
+        ODocument document = new ODocument();
+        document = prepareObjectWithPk(key);
+        Set<TupleOperation> operations = tuple.getOperations();
+        for (TupleOperation op : operations) {
+            String column = op.getColumn();
 
-		}
-		else {
-			// it is old record =>update the record
-			log.info( "insertOrUpdateTuple:Key:" + dbKey + "is persistent!. Update old record" );
-		}
-	}
+        }
+    }
 
-	@Override
-	public void insertTuple(EntityKeyMetadata entityKeyMetadata, Tuple tuple, TupleContext tupleContext) {
-		log.info( "insertTuple:EntityKeyMetadata:" + entityKeyMetadata + "; tupleContext" + tupleContext + "; tuple:" + tuple );
-		throw new UnsupportedOperationException( "Not supported yet." );
-	}
+    @Override
+    public void removeTuple(EntityKey key, TupleContext tupleContext) {
+        log.info("removeTuple:EntityKey:" + key + "; tupleContext" + tupleContext);
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 
-	@Override
-	public void removeTuple(EntityKey key, TupleContext tupleContext) {
-		log.info( "removeTuple:EntityKey:" + key + "; tupleContext" + tupleContext );
-		throw new UnsupportedOperationException( "Not supported yet." );
-	}
+    @Override
+    public Association getAssociation(AssociationKey key, AssociationContext associationContext) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 
-	@Override
-	public Association getAssociation(AssociationKey key, AssociationContext associationContext) {
-		throw new UnsupportedOperationException( "Not supported yet." );
-	}
+    @Override
+    public Association createAssociation(AssociationKey key, AssociationContext associationContext) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 
-	@Override
-	public Association createAssociation(AssociationKey key, AssociationContext associationContext) {
-		throw new UnsupportedOperationException( "Not supported yet." );
-	}
+    @Override
+    public void insertOrUpdateAssociation(AssociationKey key, Association association, AssociationContext associationContext) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 
-	@Override
-	public void insertOrUpdateAssociation(AssociationKey key, Association association, AssociationContext associationContext) {
-		throw new UnsupportedOperationException( "Not supported yet." );
-	}
+    @Override
+    public void removeAssociation(AssociationKey key, AssociationContext associationContext) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 
-	@Override
-	public void removeAssociation(AssociationKey key, AssociationContext associationContext) {
-		throw new UnsupportedOperationException( "Not supported yet." );
-	}
+    @Override
+    public boolean isStoredInEntityStructure(AssociationKeyMetadata associationKeyMetadata, AssociationTypeContext associationTypeContext) {
+        return true;
+    }
 
-	@Override
-	public boolean isStoredInEntityStructure(AssociationKeyMetadata associationKeyMetadata, AssociationTypeContext associationTypeContext) {
-		return true;
-	}
+    @Override
+    public Number nextValue(NextValueRequest request) {
+        log.info("NextValueRequest:" + request + "; ");
+        return ORecordId.EMPTY_RECORD_ID.getClusterPosition();
+    }
 
-	@Override
-	public Number nextValue(NextValueRequest request) {
-		log.info( "NextValueRequest:" + request + "; " );
-		return ORecordId.EMPTY_RECORD_ID.getClusterPosition();
-	}
+    @Override
+    public boolean supportsSequences() {
+        return super.supportsSequences(); // To change body of generated methods, choose Tools | Templates.
+    }
 
-	@Override
-	public boolean supportsSequences() {
-		return super.supportsSequences(); // To change body of generated methods, choose Tools | Templates.
-	}
+    @Override
+    public void forEachTuple(ModelConsumer consumer, EntityKeyMetadata... entityKeyMetadatas) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 
-	@Override
-	public void forEachTuple(ModelConsumer consumer, EntityKeyMetadata... entityKeyMetadatas) {
-		throw new UnsupportedOperationException( "Not supported yet." );
-	}
-
-	@Override
-	public void sessionFactoryCreated(SessionFactoryImplementor sessionFactoryImplementor) {
-
-		this.associationQueries = initializeAssociationQueries( sessionFactoryImplementor );
-		this.entityQueries = initializeEntityQueries( sessionFactoryImplementor, associationQueries );
-	}
-
-	private Map<EntityKeyMetadata, OrientDBEntityQueries> initializeEntityQueries(SessionFactoryImplementor sessionFactoryImplementor,
-			Map<AssociationKeyMetadata, OrientDBAssociationQueries> associationQueries) {
-		Map<EntityKeyMetadata, OrientDBEntityQueries> entityQueries = initializeEntityQueries( sessionFactoryImplementor );
-		for ( AssociationKeyMetadata associationKeyMetadata : associationQueries.keySet() ) {
-			EntityKeyMetadata entityKeyMetadata = associationKeyMetadata.getAssociatedEntityKeyMetadata().getEntityKeyMetadata();
-			if ( !entityQueries.containsKey( entityKeyMetadata ) ) {
-				// Embeddables metadata
-				entityQueries.put( entityKeyMetadata, new OrientDBEntityQueries( entityKeyMetadata ) );
-			}
-		}
-		return entityQueries;
-	}
-
-	private Map<EntityKeyMetadata, OrientDBEntityQueries> initializeEntityQueries(SessionFactoryImplementor sessionFactoryImplementor) {
-		Map<EntityKeyMetadata, OrientDBEntityQueries> queryMap = new HashMap<EntityKeyMetadata, OrientDBEntityQueries>();
-		Collection<EntityPersister> entityPersisters = sessionFactoryImplementor.getEntityPersisters().values();
-		for ( EntityPersister entityPersister : entityPersisters ) {
-			if ( entityPersister instanceof OgmEntityPersister ) {
-				OgmEntityPersister ogmEntityPersister = (OgmEntityPersister) entityPersister;
-				queryMap.put( ogmEntityPersister.getEntityKeyMetadata(), new OrientDBEntityQueries( ogmEntityPersister.getEntityKeyMetadata() ) );
-			}
-		}
-		return queryMap;
-	}
-
-	private Map<AssociationKeyMetadata, OrientDBAssociationQueries> initializeAssociationQueries(SessionFactoryImplementor sessionFactoryImplementor) {
-		Map<AssociationKeyMetadata, OrientDBAssociationQueries> queryMap = new HashMap<AssociationKeyMetadata, OrientDBAssociationQueries>();
-		Collection<CollectionPersister> collectionPersisters = sessionFactoryImplementor.getCollectionPersisters().values();
-		for ( CollectionPersister collectionPersister : collectionPersisters ) {
-			if ( collectionPersister instanceof OgmCollectionPersister ) {
-				OgmCollectionPersister ogmCollectionPersister = (OgmCollectionPersister) collectionPersister;
-				EntityKeyMetadata ownerEntityKeyMetadata = ( (OgmEntityPersister) ( ogmCollectionPersister.getOwnerEntityPersister() ) ).getEntityKeyMetadata();
-				AssociationKeyMetadata associationKeyMetadata = ogmCollectionPersister.getAssociationKeyMetadata();
-				queryMap.put( associationKeyMetadata, new OrientDBAssociationQueries( ownerEntityKeyMetadata, associationKeyMetadata ) );
-			}
-		}
-		return queryMap;
-	}
-
-	@Override
-	public GridType overrideType(Type type) {
-		log.info( "overrideType:" + type.getName() + ";" + type.getReturnedClass() );
-		GridType gridType = null;
-		if ( type.getName().equals( "com.orientechnologies.orient.core.id.ORecordId" ) ) {
-			gridType = ORecordIdGridType.INSTANCE;
-		}
-		else {
-			gridType = super.overrideType( type ); // To change body of generated methods, choose Tools | Templates.
-		}
-		return gridType;
-	}
+    @Override
+    public GridType overrideType(Type type) {
+        log.info("overrideType:" + type.getName() + ";" + type.getReturnedClass());
+        GridType gridType = null;
+        if (type.getName().equals("com.orientechnologies.orient.core.id.ORecordId")) {
+            gridType = ORecordIdGridType.INSTANCE;
+        } else {
+            gridType = super.overrideType(type); // To change body of generated methods, choose Tools | Templates.
+        }
+        return gridType;
+    }
 
 }

--- a/orientdb/src/main/java/org/hibernate/datastore/ogm/orientdb/OrientDBProperties.java
+++ b/orientdb/src/main/java/org/hibernate/datastore/ogm/orientdb/OrientDBProperties.java
@@ -1,0 +1,22 @@
+package org.hibernate.datastore.ogm.orientdb;
+
+import org.hibernate.ogm.datastore.document.cfg.DocumentStoreProperties;
+
+/**
+ * Created by cristhiank on 3/6/16.
+ */
+public final class OrientDBProperties implements DocumentStoreProperties {
+
+
+    /**
+     * Configuration property to define which engine is the app using.
+     * Default: remote
+     * <p>
+     * see http://orientdb.com/docs/2.1/Concepts.html#database-url
+     */
+    public static final String ENGINE = "hibernate.ogm.orientdb.engine";
+
+
+    private OrientDBProperties() {
+    }
+}

--- a/orientdb/src/main/java/org/hibernate/datastore/ogm/orientdb/configuration/impl/OrientDBConfiguration.java
+++ b/orientdb/src/main/java/org/hibernate/datastore/ogm/orientdb/configuration/impl/OrientDBConfiguration.java
@@ -1,0 +1,45 @@
+package org.hibernate.datastore.ogm.orientdb.configuration.impl;
+
+import org.hibernate.datastore.ogm.orientdb.OrientDBProperties;
+import org.hibernate.datastore.ogm.orientdb.options.OrientDBEngine;
+import org.hibernate.ogm.cfg.spi.DocumentStoreConfiguration;
+import org.hibernate.ogm.cfg.spi.Hosts;
+import org.hibernate.ogm.options.spi.OptionsContext;
+import org.hibernate.ogm.util.configurationreader.spi.ConfigurationPropertyReader;
+
+/**
+ * Configuration for {@link org.hibernate.datastore.ogm.orientdb.impl.OrientDBDatastoreProvider}.
+ *
+ * @author Cristhian Lopez
+ */
+public class OrientDBConfiguration extends DocumentStoreConfiguration {
+    public static final int DEFAULT_HTTP_PORT = 2480;
+    private static final String URL_SEPARATOR = ":";
+    private static final String DB_SEPARATOR = "/";
+    public static final int DEFAULT_BIN_PORT = 2424;
+    private final ConfigurationPropertyReader propertyReader;
+
+    public OrientDBConfiguration(ConfigurationPropertyReader propertyReader, OptionsContext globalOptions) {
+        super(propertyReader, DEFAULT_BIN_PORT);
+        this.propertyReader = propertyReader;
+    }
+
+    public String buildOrientDBUrl() {
+        StringBuilder url = new StringBuilder();
+        OrientDBEngine engine = propertyReader.property(OrientDBProperties.ENGINE, OrientDBEngine.class).withDefault(OrientDBEngine.REMOTE).getValue();
+        Hosts.HostAndPort firstHost = getHosts().getFirst();
+        url.append(engine.getName());
+        url.append(URL_SEPARATOR);
+        if (engine == OrientDBEngine.MEMORY || engine == OrientDBEngine.PLOCAL) {
+            url.append(getDatabaseName());
+        } else if (engine == OrientDBEngine.REMOTE) {
+            url.append(firstHost.getHost());
+            url.append(URL_SEPARATOR);
+            url.append(firstHost.getPort());
+            if (!getDatabaseName().startsWith(DB_SEPARATOR))
+                url.append(DB_SEPARATOR);
+            url.append(getDatabaseName());
+        }
+        return url.toString();
+    }
+}

--- a/orientdb/src/main/java/org/hibernate/datastore/ogm/orientdb/dialect/impl/OrientDBQueryHelper.java
+++ b/orientdb/src/main/java/org/hibernate/datastore/ogm/orientdb/dialect/impl/OrientDBQueryHelper.java
@@ -1,0 +1,29 @@
+package org.hibernate.datastore.ogm.orientdb.dialect.impl;
+
+import com.orientechnologies.orient.core.id.ORecordId;
+import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
+import org.hibernate.ogm.model.key.spi.EntityKey;
+
+/**
+ * @author cristhiank on 3/6/16 (calovi86 at gmail.com).
+ */
+public class OrientDBQueryHelper {
+    public static <T> OSQLSynchQuery<T> createSelect(EntityKey key) {
+        String[] columnNames = key.getColumnNames();
+        Object[] columnValues = key.getColumnValues();
+        StringBuilder query = new StringBuilder("SELECT FROM ");
+        if (columnValues.length == 1 && columnValues[0] instanceof ORecordId) {
+            query.append(columnValues[0]);
+        } else if (columnValues.length > 0) {
+            query.append(" WHERE ");
+            int i = 0;
+            do {
+                if (i > 0) {
+                    query.append(" AND ");
+                }
+                query.append(columnNames[i]).append("=").append(columnValues[i]);
+            } while (i++ < columnNames.length);
+        }
+        return new OSQLSynchQuery<T>(query.toString());
+    }
+}

--- a/orientdb/src/main/java/org/hibernate/datastore/ogm/orientdb/dialect/impl/OrientDBTupleSnapshot.java
+++ b/orientdb/src/main/java/org/hibernate/datastore/ogm/orientdb/dialect/impl/OrientDBTupleSnapshot.java
@@ -6,57 +6,61 @@
  */
 package org.hibernate.datastore.ogm.orientdb.dialect.impl;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
-import org.hibernate.datastore.ogm.orientdb.logging.impl.Log;
-import org.hibernate.datastore.ogm.orientdb.logging.impl.LoggerFactory;
-import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
+import com.orientechnologies.orient.core.record.impl.ODocument;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.model.spi.TupleSnapshot;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * @author chernolyassv
+ * @author cristhiank (calovi86@gmail.com)
  */
 public class OrientDBTupleSnapshot implements TupleSnapshot {
 
-	private static Log LOG = LoggerFactory.getLogger();
-	private final Map<String, Object> dbNameValueMap;
+    private final ODocument orientDbRecord;
+    private final EntityKeyMetadata recordKeyMetadata;
+    private SnapshotType snapshotType;
 
-	private Map<String, AssociatedEntityKeyMetadata> associatedEntityKeyMetadata;
-	private Map<String, String> rolesByColumn;
-	private EntityKeyMetadata entityKeyMetadata;
+    public SnapshotType getSnapshotType() {
+        return snapshotType;
+    }
 
-	public OrientDBTupleSnapshot(Map<String, Object> dbNameValueMap, Map<String, AssociatedEntityKeyMetadata> associatedEntityKeyMetadata,
-			Map<String, String> rolesByColumn, EntityKeyMetadata entityKeyMetadata) {
-		this.dbNameValueMap = dbNameValueMap;
-		this.associatedEntityKeyMetadata = associatedEntityKeyMetadata;
-		this.rolesByColumn = rolesByColumn;
-		this.entityKeyMetadata = entityKeyMetadata;
-		LOG.info( "dbNameValueMap:" + dbNameValueMap );
-	}
+    public void setSnapshotType(SnapshotType snapshotType) {
+        this.snapshotType = snapshotType;
+    }
 
-	public OrientDBTupleSnapshot(EntityKeyMetadata entityKeyMetadata) {
-		this( new HashMap<String, Object>(), null, null, entityKeyMetadata );
-	}
+    public enum SnapshotType {
+        INSERT, UPDATE
+    }
 
-	@Override
-	public Object get(String targetColumnName) {
-		LOG.info( "targetColumnName: " + targetColumnName );
-		return dbNameValueMap.get( targetColumnName );
-	}
+    public OrientDBTupleSnapshot(ODocument record, EntityKeyMetadata meta, SnapshotType type) {
+        this.orientDbRecord = record;
+        this.recordKeyMetadata = meta;
+        this.snapshotType = type;
+    }
 
-	@Override
-	public boolean isEmpty() {
-		LOG.info( "isEmpty" );
-		return dbNameValueMap.isEmpty();
-	}
+    @Override
+    public Object get(String column) {
+        return getOrientDbRecord().field(column);
+    }
 
-	@Override
-	public Set<String> getColumnNames() {
-		LOG.info( "getColumnNames" );
-		return dbNameValueMap.keySet();
-	}
+    @Override
+    public boolean isEmpty() {
+        return getOrientDbRecord().isEmpty();
+    }
+
+    @Override
+    public Set<String> getColumnNames() {
+        Set<String> columnNames = new HashSet<>();
+        Collections.addAll(columnNames, getOrientDbRecord().fieldNames());
+        return columnNames;
+    }
+
+    public ODocument getOrientDbRecord() {
+        return orientDbRecord;
+    }
 
 }

--- a/orientdb/src/main/java/org/hibernate/datastore/ogm/orientdb/impl/OrientDBDatastoreProvider.java
+++ b/orientdb/src/main/java/org/hibernate/datastore/ogm/orientdb/impl/OrientDBDatastoreProvider.java
@@ -6,98 +6,86 @@
  */
 package org.hibernate.datastore.ogm.orientdb.impl;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.util.Map;
-import java.util.Properties;
+import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
+import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.datastore.ogm.orientdb.OrientDBDialect;
+import org.hibernate.datastore.ogm.orientdb.configuration.impl.OrientDBConfiguration;
 import org.hibernate.datastore.ogm.orientdb.logging.impl.Log;
 import org.hibernate.datastore.ogm.orientdb.logging.impl.LoggerFactory;
-import org.hibernate.engine.jndi.spi.JndiService;
-import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform;
 import org.hibernate.ogm.datastore.spi.BaseDatastoreProvider;
 import org.hibernate.ogm.datastore.spi.SchemaDefiner;
 import org.hibernate.ogm.dialect.spi.GridDialect;
+import org.hibernate.ogm.options.spi.OptionsService;
 import org.hibernate.ogm.util.configurationreader.spi.ConfigurationPropertyReader;
-import org.hibernate.ogm.util.configurationreader.spi.PropertyReaderContext;
-import org.hibernate.service.spi.Configurable;
-import org.hibernate.service.spi.ServiceRegistryAwareService;
-import org.hibernate.service.spi.ServiceRegistryImplementor;
-import org.hibernate.service.spi.Startable;
-import org.hibernate.service.spi.Stoppable;
+import org.hibernate.service.spi.*;
+
+import java.util.Map;
 
 /**
  * @author chernolyassv
+ * @author cristhiank (calovi86 at gmail.com)
  */
 public class OrientDBDatastoreProvider extends BaseDatastoreProvider implements Startable, Stoppable, Configurable, ServiceRegistryAwareService {
 
-	private static Log LOG = LoggerFactory.getLogger();
-	private ConfigurationPropertyReader propertyReader;
-	private ServiceRegistryImplementor registry;
-	private JtaPlatform jtaPlatform;
-	private JndiService jndiService;
+    private static Log LOG = LoggerFactory.getLogger();
+    private ODatabaseDocumentTx orientdb;
+    private OrientDBConfiguration config;
+    private ServiceRegistryImplementor serviceRegistry;
 
-	private Connection connection;
+    @Override
+    public Class<? extends GridDialect> getDefaultDialect() {
+        return OrientDBDialect.class;
+    }
 
-	@Override
-	public Class<? extends GridDialect> getDefaultDialect() {
-		return OrientDBDialect.class;
-	}
+    @Override
+    public void start() {
+        LOG.info("start");
+        try {
+            if (orientdb == null) {
+                orientdb = createOrientDbConnection(config);
+            }
+        } catch (Exception e) {
+            throw LOG.unableToStartDatastoreProvider(e);
+        }
+    }
 
-	@Override
-	public void start() {
-		LOG.info( "start" );
-		try {
-			PropertyReaderContext<String> jdbcUrlPropery = propertyReader.property( "javax.persistence.jdbc.url", String.class );
-			if ( jdbcUrlPropery != null ) {
-				String jdbcUrl = jdbcUrlPropery.getValue();
-				LOG.info( "jdbcUrl:" + jdbcUrl );
-				Class.forName( propertyReader.property( "javax.persistence.jdbc.driver", String.class ).getValue() ).newInstance();
-				Properties info = new Properties();
-				info.put( "user", propertyReader.property( "javax.persistence.jdbc.user", String.class ).getValue() );
-				info.put( "password", propertyReader.property( "javax.persistence.jdbc.password", String.class ).getValue() );
+    private ODatabaseDocumentTx createOrientDbConnection(OrientDBConfiguration config) {
+        ODatabaseDocumentTx connection = new ODatabaseDocumentTx(config.buildOrientDBUrl());
+        connection.open(config.getUsername(), config.getPassword());
+        return connection;
+    }
 
-				connection = DriverManager.getConnection( jdbcUrl, info );
+    public ODatabaseDocumentTx getConnection() {
+        return orientdb;
+    }
 
-			}
+    @Override
+    public void stop() {
+        LOG.info("stop");
+        if (!orientdb.isClosed()) {
+            orientdb.close();
+        }
+    }
 
-		}
-		catch (Exception e) {
-			throw LOG.unableToStartDatastoreProvider( e );
-		}
-	}
+    @Override
+    public void configure(Map configurationValues) {
+        LOG.info("config map:" + configurationValues.toString());
+        OptionsService optionsService = serviceRegistry.getService(OptionsService.class);
+        ClassLoaderService classLoaderService = serviceRegistry.getService(ClassLoaderService.class);
+        ConfigurationPropertyReader propertyReader = new ConfigurationPropertyReader(configurationValues, classLoaderService);
+        this.config = new OrientDBConfiguration(propertyReader, optionsService.context().getGlobalOptions());
 
-	public Connection getConnection() {
-		return connection;
-	}
+    }
 
-	public void setConnection(Connection connection) {
-		this.connection = connection;
-	}
+    @Override
+    public void injectServices(ServiceRegistryImplementor serviceRegistry) {
+        this.serviceRegistry = serviceRegistry;
+    }
 
-	@Override
-	public void stop() {
-		LOG.info( "stop" );
-	}
-
-	@Override
-	public void configure(Map cfg) {
-		LOG.info( "config map:" + cfg.toString() );
-		propertyReader = new ConfigurationPropertyReader( cfg );
-
-	}
-
-	@Override
-	public void injectServices(ServiceRegistryImplementor serviceRegistry) {
-		this.registry = serviceRegistry;
-		jtaPlatform = serviceRegistry.getService( JtaPlatform.class );
-		jndiService = serviceRegistry.getService( JndiService.class );
-	}
-
-	@Override
-	public Class<? extends SchemaDefiner> getSchemaDefinerType() {
-		LOG.info( "getSchemaDefinerType" );
-		return super.getSchemaDefinerType();
-	}
+    @Override
+    public Class<? extends SchemaDefiner> getSchemaDefinerType() {
+        LOG.info("getSchemaDefinerType");
+        return super.getSchemaDefinerType();
+    }
 
 }

--- a/orientdb/src/main/java/org/hibernate/datastore/ogm/orientdb/options/OrientDBEngine.java
+++ b/orientdb/src/main/java/org/hibernate/datastore/ogm/orientdb/options/OrientDBEngine.java
@@ -1,0 +1,18 @@
+package org.hibernate.datastore.ogm.orientdb.options;
+
+/**
+ * @author cristhiank on 3/6/16 (calovi86@gmail.com)
+ */
+public enum OrientDBEngine {
+    PLOCAL("plocal"), MEMORY("memory"), REMOTE("remote");
+
+    private final String name;
+
+    OrientDBEngine(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/orientdb/src/test/java/org/hibernte/datastore/ogm/orientdb/test/datastore/BuildOrientDBUrlTest.java
+++ b/orientdb/src/test/java/org/hibernte/datastore/ogm/orientdb/test/datastore/BuildOrientDBUrlTest.java
@@ -1,0 +1,77 @@
+package org.hibernte.datastore.ogm.orientdb.test.datastore;
+
+import org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl;
+import org.hibernate.datastore.ogm.orientdb.OrientDBProperties;
+import org.hibernate.datastore.ogm.orientdb.configuration.impl.OrientDBConfiguration;
+import org.hibernate.ogm.cfg.OgmProperties;
+import org.hibernate.ogm.options.navigation.impl.OptionsContextImpl;
+import org.hibernate.ogm.options.navigation.source.impl.OptionValueSources;
+import org.hibernate.ogm.options.spi.OptionsContext;
+import org.hibernate.ogm.util.configurationreader.spi.ConfigurationPropertyReader;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test for the {@link OrientDBConfiguration#buildOrientDBUrl()}
+ *
+ * @author cristhiank on 3/6/16 (calovi86 at gmail.com).
+ */
+public class BuildOrientDBUrlTest {
+    private static final String NON_EXISTENT_IP = "203.0.113.1";
+    private static final String NON_EXISTENT_DB = "/path/to/the/db";
+    private Map<String, Object> plocalCfg;
+    private Map<String, Object> remoteCfg;
+    private Map<String, Object> memoryCfg;
+    private OptionsContext globalOptions;
+    private ConfigurationPropertyReader reader;
+
+    @Before
+    public void setupConfigurationMapAndContexts() {
+        plocalCfg = new HashMap<>();
+        remoteCfg = new HashMap<>();
+        memoryCfg = new HashMap<>();
+
+        plocalCfg.put(OgmProperties.DATABASE, NON_EXISTENT_DB);
+        plocalCfg.put(OrientDBProperties.ENGINE, "plocal");
+
+        remoteCfg.put(OrientDBProperties.ENGINE, "remote");
+        remoteCfg.put(OgmProperties.HOST, NON_EXISTENT_IP);
+        remoteCfg.put(OgmProperties.DATABASE, NON_EXISTENT_DB);
+
+        memoryCfg.put(OgmProperties.DATABASE, NON_EXISTENT_DB);
+        memoryCfg.put(OrientDBProperties.ENGINE, "memory");
+    }
+
+    @Test
+    public void shouldBuildPLocalUrl() {
+        reader = new ConfigurationPropertyReader(plocalCfg, new ClassLoaderServiceImpl());
+        globalOptions = OptionsContextImpl.forGlobal(OptionValueSources.getDefaultSources(reader));
+        OrientDBConfiguration config = new OrientDBConfiguration(reader, globalOptions);
+        String EXPECTED_PLOCAL = "plocal:" + NON_EXISTENT_DB;
+        assertEquals(config.buildOrientDBUrl(), EXPECTED_PLOCAL);
+    }
+
+    @Test
+    public void shouldBuildRemoteUrl() {
+        reader = new ConfigurationPropertyReader(remoteCfg, new ClassLoaderServiceImpl());
+        globalOptions = OptionsContextImpl.forGlobal(OptionValueSources.getDefaultSources(reader));
+        OrientDBConfiguration config = new OrientDBConfiguration(reader, globalOptions);
+        String EXPECTED_REMOTE = "remote:" + NON_EXISTENT_IP + ":" + OrientDBConfiguration.DEFAULT_BIN_PORT + NON_EXISTENT_DB;
+        assertEquals(config.buildOrientDBUrl(), EXPECTED_REMOTE);
+    }
+
+    @Test
+    public void shouldBuildMemoryUrl() {
+        reader = new ConfigurationPropertyReader(memoryCfg, new ClassLoaderServiceImpl());
+        globalOptions = OptionsContextImpl.forGlobal(OptionValueSources.getDefaultSources(reader));
+        OrientDBConfiguration config = new OrientDBConfiguration(reader, globalOptions);
+        String EXPECTED_MEMORY = "memory:" + NON_EXISTENT_DB;
+        assertEquals(config.buildOrientDBUrl(), EXPECTED_MEMORY);
+    }
+
+}

--- a/orientdb/src/test/java/org/hibernte/datastore/ogm/orientdb/test/datastore/DatastoreInitializationTest.java
+++ b/orientdb/src/test/java/org/hibernte/datastore/ogm/orientdb/test/datastore/DatastoreInitializationTest.java
@@ -1,0 +1,70 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernte.datastore.ogm.orientdb.test.datastore;
+
+import org.hibernate.ogm.cfg.OgmProperties;
+import org.hibernate.ogm.datastore.spi.DatastoreProvider;
+import org.hibernate.ogm.utils.SkippableTestRunner;
+import org.hibernate.ogm.utils.TestHelper;
+import org.hibernate.service.spi.ServiceException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
+
+/**
+ * @author cristhiank on 3/6/16 (calovi86 at gmail.com).
+ */
+@RunWith(SkippableTestRunner.class)
+public class DatastoreInitializationTest {
+
+    private static final String NON_EXISTENT_IP = "203.0.113.1";
+
+    @Rule
+    public ExpectedException error = ExpectedException.none();
+
+    private Map<String, Object> cfg;
+
+    @Before
+    public void setUp() {
+        cfg = new HashMap<String, Object>();
+        cfg.put(OgmProperties.HOST, NON_EXISTENT_IP);
+        cfg.put(OgmProperties.DATABASE, "orientdb");
+        cfg.put(OgmProperties.USERNAME, "root");
+        cfg.put(OgmProperties.PASSWORD, "toor");
+    }
+
+    @Test
+    public void testConnectionErrorWrappedInHibernateException() throws Exception {
+        error.expect(ServiceException.class);
+        error.expectMessage("OGM000071");
+        //nested exception
+        error.expectCause(hasMessage(containsString("OGM001214")));
+
+        // will start the service
+        TestHelper.getDefaultTestStandardServiceRegistry(cfg).getService(DatastoreProvider.class);
+    }
+
+    @Test
+    public void testConnectionRefused() {
+        error.expect(ServiceException.class);
+        error.expectMessage("OGM000071");
+        // the timeout exception thrown by the driver will actually contain some information about the authentication
+        // error. Obviously quite fragile. Might change
+        error.expectCause(hasMessage(containsString("Connection refused")));
+
+        // will start the service
+        TestHelper.getDefaultTestStandardServiceRegistry(cfg).getService(DatastoreProvider.class);
+    }
+}

--- a/orientdb/src/test/java/org/hibernte/datastore/ogm/orientdb/test/dialectinvocations/GridDialectOperationInvocationsTest.java
+++ b/orientdb/src/test/java/org/hibernte/datastore/ogm/orientdb/test/dialectinvocations/GridDialectOperationInvocationsTest.java
@@ -1,0 +1,232 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernte.datastore.ogm.orientdb.test.dialectinvocations;
+
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.ogm.cfg.OgmProperties;
+import org.hibernate.ogm.dialect.impl.GridDialects;
+import org.hibernate.ogm.dialect.spi.GridDialect;
+import org.hibernate.ogm.utils.InvokedOperationsLoggingDialect;
+import org.hibernate.ogm.utils.OgmTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Asserts the number and order of grid dialect operations.
+ *
+ * @author cristhiank on 3/6/16 (calovi86 at gmail.com).
+ */
+public class GridDialectOperationInvocationsTest extends OgmTestCase {
+
+    @Before
+    public void resetOperationsLog() {
+        getOperationsLogger().reset();
+    }
+
+    @Test
+    public void insertUpdateAndDelete() throws Exception {
+        Session session = openSession();
+        Transaction transaction = session.beginTransaction();
+
+        // insert
+        StockItem item = new StockItem();
+        item.setId("item-1");
+        item.setItemName("Fairway Wood 19°");
+        item.setCount(25);
+        session.persist(item);
+
+        transaction.commit();
+        session.clear();
+        transaction = session.beginTransaction();
+
+        // load and update
+        StockItem loadedItem = (StockItem) session.get(StockItem.class, item.getId());
+        assertNotNull("Cannot load persisted object", loadedItem);
+        loadedItem.setCount(24);
+
+        transaction.commit();
+        session.clear();
+        transaction = session.beginTransaction();
+
+        // delete
+        loadedItem = (StockItem) session.get(StockItem.class, item.getId());
+        assertNotNull("Cannot load persisted object", loadedItem);
+        session.delete(loadedItem);
+
+        transaction.commit();
+        session.clear();
+        session.close();
+
+        assertThat(getOperations()).containsExactly(
+                "createTuple",
+                "executeBatch",
+                "getTuple",
+                "executeBatch",
+                "getTuple",
+                "executeBatch"
+        );
+    }
+
+    @Test
+    public void insertGetOfEntityAndElementCollectionAndDelete() throws Exception {
+        Session session = openSession();
+        Transaction transaction = session.beginTransaction();
+
+        // insert
+        Product product = new Product(
+                "product-1",
+                "Hybrid 25°",
+                new Vendor("Leaveland", 10), new Vendor("Headaway", 9)
+        );
+        session.persist(product);
+
+        transaction.commit();
+        session.clear();
+        transaction = session.beginTransaction();
+
+        // load and update
+        Product loadedProduct = (Product) session.get(Product.class, "product-1");
+        assertNotNull("Cannot load persisted object", loadedProduct);
+        assertThat(loadedProduct.getVendors()).onProperty("name").containsOnly("Leaveland", "Headaway");
+
+        transaction.commit();
+        session.clear();
+        transaction = session.beginTransaction();
+
+        // delete
+        loadedProduct = (Product) session.get(Product.class, "product-1");
+        assertNotNull("Cannot load persisted object", loadedProduct);
+        session.delete(loadedProduct);
+
+        transaction.commit();
+        session.clear();
+        session.close();
+
+        assertThat(getOperations()).containsExactly(
+                "createTuple",
+                "getAssociation",
+                "executeBatch",
+                "getTuple",
+                "getAssociation",
+                "getTuple",
+                "getAssociation",
+                "removeAssociation",
+                "removeTuple",
+                "executeBatch"
+        );
+    }
+
+    @Test
+    public void insertAndUpdateInSameTransaction() throws Exception {
+        Session session = openSession();
+        Transaction transaction = session.beginTransaction();
+
+        // insert
+        StockItem item = new StockItem();
+        item.setId("item-1");
+        item.setItemName("Fairway Wood 19°");
+        item.setCount(25);
+        session.persist(item);
+
+        session.flush();
+
+        // update
+        item.setCount(24);
+
+        transaction.commit();
+        session.clear();
+        transaction = session.beginTransaction();
+
+        StockItem loadedItem = (StockItem) session.get(StockItem.class, item.getId());
+        assertNotNull("Cannot load persisted object", loadedItem);
+        session.delete(loadedItem);
+
+        transaction.commit();
+        session.close();
+
+        assertThat(getOperations()).containsExactly(
+                "createTuple",
+                "executeBatch",
+                "executeBatch",
+                "getTuple",
+                "executeBatch"
+        );
+    }
+
+    @Test
+    public void insertSearchUpdateDelete() throws Exception {
+        Session session = openSession();
+        Transaction transaction = session.beginTransaction();
+
+        // insert
+        StockItem item = new StockItem();
+        item.setId("item-1");
+        item.setItemName("Fairway Wood 19°");
+        item.setCount(25);
+        session.persist(item);
+
+        transaction.commit();
+        session.clear();
+        transaction = session.beginTransaction();
+
+        // search and update
+        StockItem loadedItem = (StockItem) session.createQuery("from StockItem si").uniqueResult();
+        assertNotNull("Cannot load persisted object", loadedItem);
+        loadedItem.setCount(24);
+
+        transaction.commit();
+        session.clear();
+        transaction = session.beginTransaction();
+
+        loadedItem = (StockItem) session.get(StockItem.class, item.getId());
+        assertNotNull("Cannot load persisted object", loadedItem);
+        assertThat(loadedItem.getCount()).isEqualTo(24);
+        session.delete(loadedItem);
+
+        transaction.commit();
+        session.close();
+        assertThat(getOperations()).containsExactly(
+                "createTuple",
+                "executeBatch",
+                "executeBackendQuery",
+                "executeBatch",
+                "getTuple",
+                "executeBatch"
+        );
+    }
+
+    @Override
+    protected Class<?>[] getAnnotatedClasses() {
+        return new Class<?>[]{StockItem.class, Product.class};
+    }
+
+    @Override
+    protected void configure(Map<String, Object> settings) {
+        settings.put(OgmProperties.GRID_DIALECT, InvokedOperationsLoggingDialect.class);
+    }
+
+    private InvokedOperationsLoggingDialect getOperationsLogger() {
+        GridDialect gridDialect = sfi().getServiceRegistry().getService(GridDialect.class);
+        InvokedOperationsLoggingDialect invocationLogger = GridDialects.getDelegateOrNull(
+                gridDialect,
+                InvokedOperationsLoggingDialect.class
+        );
+
+        return invocationLogger;
+    }
+
+    private List<String> getOperations() {
+        return getOperationsLogger().getOperations();
+    }
+}

--- a/orientdb/src/test/java/org/hibernte/datastore/ogm/orientdb/test/dialectinvocations/Product.java
+++ b/orientdb/src/test/java/org/hibernte/datastore/ogm/orientdb/test/dialectinvocations/Product.java
@@ -1,0 +1,62 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernte.datastore.ogm.orientdb.test.dialectinvocations;
+
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Gunnar Morling
+ */
+@Entity
+public class Product {
+
+	private String id;
+	private String itemName;
+	private List<Vendor> vendors = new ArrayList<Vendor>();
+
+	Product() {
+	}
+
+	public Product(String id, String itemName, Vendor... vendors) {
+		this.id = id;
+		this.itemName = itemName;
+		if ( vendors != null ) {
+			this.vendors.addAll( Arrays.asList( vendors ) );
+		}
+	}
+
+	@Id
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getItemName() {
+		return itemName;
+	}
+
+	public void setItemName(String itemName) {
+		this.itemName = itemName;
+	}
+
+	@ElementCollection
+	public List<Vendor> getVendors() {
+		return vendors;
+	}
+
+	public void setVendors(List<Vendor> vendors) {
+		this.vendors = vendors;
+	}
+}

--- a/orientdb/src/test/java/org/hibernte/datastore/ogm/orientdb/test/dialectinvocations/StockItem.java
+++ b/orientdb/src/test/java/org/hibernte/datastore/ogm/orientdb/test/dialectinvocations/StockItem.java
@@ -1,0 +1,48 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernte.datastore.ogm.orientdb.test.dialectinvocations;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+/**
+ * @author Gunnar Morling
+ */
+@Entity
+public class StockItem {
+
+	private String id;
+	private String itemName;
+	private int count;
+
+	@Id
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getItemName() {
+		return itemName;
+	}
+
+	public void setItemName(String itemName) {
+		this.itemName = itemName;
+	}
+
+	@Column(name = "cnt")
+	public int getCount() {
+		return count;
+	}
+
+	public void setCount(int count) {
+		this.count = count;
+	}
+}

--- a/orientdb/src/test/java/org/hibernte/datastore/ogm/orientdb/test/dialectinvocations/Vendor.java
+++ b/orientdb/src/test/java/org/hibernte/datastore/ogm/orientdb/test/dialectinvocations/Vendor.java
@@ -1,0 +1,43 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernte.datastore.ogm.orientdb.test.dialectinvocations;
+
+import javax.persistence.Embeddable;
+
+/**
+ * @author Gunnar Morling
+ */
+@Embeddable
+public class Vendor {
+
+	private String name;
+	private int rating;
+
+	Vendor() {
+	}
+
+	public Vendor(String name, int rating) {
+		this.name = name;
+		this.rating = rating;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public int getRating() {
+		return rating;
+	}
+
+	public void setRating(int rating) {
+		this.rating = rating;
+	}
+}

--- a/orientdb/src/test/resources/hibernate.properties
+++ b/orientdb/src/test/resources/hibernate.properties
@@ -16,3 +16,5 @@
 # MA 02110-1301  USA
 
 hibernate.ogm.datastore.provider = ORIENTDB
+hibernate.ogm.datastore.database = orientdb_test_db
+hibernate.ogm.datastore.engine = memory


### PR DESCRIPTION
Hi DavideD,

What do you think of this approach to integrate OrientDB, I'm using MongoDB as inspiration.
It's still in premature state but the initial tests work fine.

Regards,

Cristhian.

The main changes are:

Use native java api to connect to orientdb not JDBC.
Use native queries.
Use ODocument as base record, it's orientdb base implementation for Graph and Document database modes.
Allow connection to in memory, plocal and remote engines.
Updated target version to OrientDB 2.1.12
Added some test to configuration and initialization.
Heavy work in progress.